### PR TITLE
Handle and support NO_PROXY

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ I have embedded `resty.Client` into `simpleresty.Client` so all of `resty`'s fun
 In fact, `simpleresty.New()` returns a `resty.Client`.
 
 ## Example
-
 ```go
 package main
 
@@ -41,10 +40,13 @@ func main() {
 }
 ```
 
+Additional examples can be found in the `/examples` folder.
+
 You can also check out [rollrest-go](https://github.com/davidji99/rollrest-go), which uses this library to implement
 an API rest client for Rollbar.
 
 ## Proxy
+
 `simpleresty` respects any proxy URLs set in your environment in this order of preference:
 1. `HTTPS_PROXY`
 1. `https_proxy`
@@ -52,6 +54,9 @@ an API rest client for Rollbar.
 1. `http_proxy`
 
 Only a single value from one of the above four environment variables will be used to set the proxy URL on the `Client`.
+
+`simpleresty` will also respect domains (not IP addresses or CIDR ranges) defined by the `NO_PROXY` or `no_proxy`
+environment variable. Multiple domains must be separated by a comma.
 
 ## Go-Resty
 As this pkg is a thin wrapper around go-resty, all of its methods are available to use in this package.

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package simpleresty
 import (
 	"fmt"
 	"github.com/go-resty/resty/v2"
+	"os"
 )
 
 const (
@@ -105,6 +106,11 @@ func (c *Client) ConstructRequest(r, body interface{}) *resty.Request {
 
 // RequestURL appends the template argument to the base URL and returns the full request URL.
 func (c *Client) RequestURL(template string, args ...interface{}) string {
+	// Validate to make sure baseURL is set
+	if c.baseURL == "" {
+		panic("base URL not set")
+	}
+
 	if len(args) == 1 && args[0] == "" {
 		return c.baseURL + template
 	}
@@ -122,4 +128,16 @@ func (c *Client) RequestURLWithQueryParams(url string, opts ...interface{}) (str
 // SetBaseURL sets the base url for the client.
 func (c *Client) SetBaseURL(url string) {
 	c.baseURL = url
+}
+
+func (c *Client) determineSetProxy() {
+	noProxyDomains, _ := getNoProxyDomains()
+
+	for _, v := range proxyVars {
+		proxyURL := os.Getenv(v)
+		if proxyURL != "" && !contains(noProxyDomains, proxyURL, true) {
+			c.SetProxy(proxyURL)
+			break
+		}
+	}
 }

--- a/client.go
+++ b/client.go
@@ -146,6 +146,10 @@ func (c *Client) SetBaseURL(url string) {
 	c.baseURL = url
 }
 
+// determineSetProxy first checks if proxy is already set or not. If it is, this method returns early.
+//
+// If no proxy is set, it will be set if the proxyURL is defined and the base domain is not present
+// in the noProxyDomains string array.
 func (c *Client) determineSetProxy() {
 	// If proxy is already set in a previous execution, short circuit this method call.
 	if c.IsProxySet() {

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,97 @@
+package simpleresty
+
+import (
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestClient_RequestURL_BaseUrlSet(t *testing.T) {
+	c := &Client{Client: resty.New(), baseURL: "https://sass.com/api/v1"}
+	assert.Equal(t, "https://sass.com/api/v1/apps", c.RequestURL("/apps"))
+}
+
+func TestClient_RequestURL_BaseUrlSetWithArgs(t *testing.T) {
+	c := &Client{Client: resty.New(), baseURL: "https://sass.com/api/v1"}
+	assert.Equal(t, "https://sass.com/api/v1/apps/123", c.RequestURL("/apps/%s", "123"))
+}
+
+func TestClient_RequestURL_BaseUrlNotSet(t *testing.T) {
+	c := &Client{Client: resty.New()}
+	assert.Panics(t, func() { c.RequestURL("/apps") })
+}
+
+func TestClient_SetBaseURL(t *testing.T) {
+	c := &Client{Client: resty.New()}
+	c.SetBaseURL("https://www.google.com/api/v1")
+
+	assert.Equal(t, "https://www.google.com/api/v1", c.baseURL)
+}
+
+func TestClient_RequestURLWithQueryParams(t *testing.T) {
+	c := &Client{Client: resty.New(), baseURL: "https://sass.com/api/v1"}
+	queryParams := struct {
+		Since string `url:"since,omitempty"`
+		Page  int    `url:"page,omitempty"`
+	}{
+		Since: "3days",
+		Page:  4,
+	}
+
+	url, err := c.RequestURLWithQueryParams("/apps", queryParams)
+	assert.Nil(t, err)
+	assert.Equal(t, "https://sass.com/api/v1/apps?page=4&since=3days", url)
+}
+
+func TestClient_RequestURLWithNoQueryParams(t *testing.T) {
+	c := &Client{Client: resty.New(), baseURL: "https://sass.com/api/v1"}
+	url, err := c.RequestURLWithQueryParams("/apps")
+	assert.Nil(t, err)
+	assert.Equal(t, "https://sass.com/api/v1/apps", url)
+}
+
+func TestDetermineSetProxy_HttpsBasic(t *testing.T) {
+	proxyURL := "some.url:8080"
+	c := &Client{Client: resty.New()}
+	c.proxyURL = &proxyURL
+
+	setErr := os.Setenv("https_proxy", "some.url:8080")
+	assert.Nil(t, setErr)
+
+	c.determineSetProxy()
+
+	assert.Equal(t, true, c.IsProxySet())
+
+	_ = os.Setenv("https_proxy", "")
+}
+
+func TestDetermineSetProxy_WithNoProxySet(t *testing.T) {
+	proxyURL := "some.url:8080"
+	c := &Client{Client: resty.New()}
+	c.proxyURL = &proxyURL
+	c.noProxyDomains = []string{"somedirect0.url", "somedirecturl.com"}
+
+	c.SetBaseURL("https://somedirecturl.com/api/1")
+
+	c.determineSetProxy()
+
+	assert.Equal(t, false, c.IsProxySet())
+}
+
+func TestDetermineSetProxy_NoneSet(t *testing.T) {
+	c := &Client{Client: resty.New()}
+
+	c.determineSetProxy()
+
+	assert.Equal(t, false, c.IsProxySet())
+}
+
+func TestDetermineSetProxy_ProxyAlreadySet(t *testing.T) {
+	c := &Client{Client: resty.New()}
+	c.SetProxy("some.url:8080")
+
+	c.determineSetProxy()
+
+	assert.Equal(t, true, c.IsProxySet())
+}

--- a/helper.go
+++ b/helper.go
@@ -1,0 +1,18 @@
+package simpleresty
+
+import "strings"
+
+func contains(a []string, x string, ignoreCase bool) bool {
+	for _, n := range a {
+		if ignoreCase {
+			if strings.ToLower(x) == strings.ToLower(n) {
+				return true
+			}
+		} else {
+			if x == n {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/proxy.go
+++ b/proxy.go
@@ -11,28 +11,29 @@ var (
 	noProxyVars = []string{"NO_PROXY", "no_proxy"}
 )
 
-func parseProxyForServer(proxyURL string) string {
-	var serverRaw string
+// parseProxyURLForDomain parses a proxy URL <protocol><server>:<port> and returns just the domain.
+func parseProxyURLForDomain(proxyURL string) string {
+	var domainRaw string
 
 	// Split proxyURL by '@' to account for username/password in the URL
 	proxyURLSplitted := strings.Split(proxyURL, "@")
 
 	if len(proxyURLSplitted) == 1 {
 		// If no username/password in URL, return proxyURLSplitted's zero index
-		serverRaw = strings.ToLower(proxyURLSplitted[0])
+		domainRaw = strings.ToLower(proxyURLSplitted[0])
 	} else {
 		// Take the 1st index value
-		serverRaw = proxyURLSplitted[1]
+		domainRaw = proxyURLSplitted[1]
 	}
 
 	// Strip out the protocol
 	regex := regexp.MustCompile(`http[s]?://`)
-	serverRaw = regex.ReplaceAllString(serverRaw, "")
+	domainRaw = regex.ReplaceAllString(domainRaw, "")
 
 	// Split by colon to separate server from PORT and get the zero index
-	server := strings.Split(serverRaw, ":")[0]
+	domain := strings.Split(domainRaw, ":")[0]
 
-	return strings.ToLower(server)
+	return strings.ToLower(domain)
 }
 
 // getNoProxyDomains fetches no proxy variables from the environment and parses each variable value for domains.
@@ -76,6 +77,11 @@ func getNoProxyDomains() ([]string, bool) {
 	return noProxyDomains, len(noProxyDomains) > 0
 }
 
+// getProxyURL gets any proxy urls from one of the four environment variables:
+// - HTTPS_PROXY
+// - https_proxy
+// - HTTP_PROXY
+// - http_proxy
 func getProxyURL() *string {
 	for _, v := range proxyVars {
 		proxyURL, isVarSet := os.LookupEnv(v)

--- a/proxy.go
+++ b/proxy.go
@@ -1,0 +1,77 @@
+package simpleresty
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+var (
+	proxyVars   = []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"}
+	noProxyVars = []string{"NO_PROXY", "no_proxy"}
+)
+
+func parseProxyForServer(proxyURL string) string {
+	var serverRaw string
+
+	// Split proxyURL by '@' to account for username/password in the URL
+	proxyURLSplitted := strings.Split(proxyURL, "@")
+
+	if len(proxyURLSplitted) == 1 {
+		// If no username/password in URL, return proxyURLSplitted's zero index
+		serverRaw = strings.ToLower(proxyURLSplitted[0])
+	} else {
+		// Take the 1st index value
+		serverRaw = proxyURLSplitted[1]
+	}
+
+	// Strip out the protocol
+	regex := regexp.MustCompile(`http[s]?://`)
+	serverRaw = regex.ReplaceAllString(serverRaw, "")
+
+	// Split by colon to separate server from PORT and get the zero index
+	server := strings.Split(serverRaw, ":")[0]
+
+	return strings.ToLower(server)
+}
+
+// getNoProxyDomains fetches no proxy variables from the environment and parses each variable value for domains.
+//
+// Returns a String array of domain names (default empty) and a Boolean for if there are any no proxy domains.
+func getNoProxyDomains() ([]string, bool) {
+	noProxyDomains := make([]string, 0)
+
+	for _, v := range noProxyVars {
+		noProxyDomainString, isSet := os.LookupEnv(v)
+		if !isSet || noProxyDomainString == "" {
+			continue
+		}
+
+		// Split by comma
+		noProxyDomainsRaw := strings.Split(noProxyDomainString, ",")
+
+		// Iterate through each URL and format properly
+		for _, domainRaw := range noProxyDomainsRaw {
+			// Remove leading and trailing whitespaces
+			domainRaw = strings.TrimSpace(domainRaw)
+
+			// Strip out any wildcard notation, `*.`
+			regexWC1 := regexp.MustCompile(`\*\.`)
+			domainRaw = regexWC1.ReplaceAllString(domainRaw, "")
+
+			// Strip out any wildcard notation, `.*`
+			regexWC2 := regexp.MustCompile(`\.\*`)
+			domainRaw = regexWC2.ReplaceAllString(domainRaw, "")
+
+			// Make sure noProxyURLRaw is a valid domain, such as example.info|com|net|etc...
+			validDomainFormatRegex := regexp.MustCompile(`\S+\.\S+`)
+			isValidDomain := validDomainFormatRegex.MatchString(domainRaw)
+
+			if isValidDomain {
+				noProxyDomains = append(noProxyDomains, strings.ToLower(domainRaw))
+			}
+		}
+	}
+
+	return noProxyDomains, len(noProxyDomains) > 0
+}

--- a/proxy.go
+++ b/proxy.go
@@ -75,3 +75,19 @@ func getNoProxyDomains() ([]string, bool) {
 
 	return noProxyDomains, len(noProxyDomains) > 0
 }
+
+func getProxyURL() *string {
+	for _, v := range proxyVars {
+		proxyURL, isVarSet := os.LookupEnv(v)
+		if !isVarSet {
+			continue
+		}
+
+		if proxyURL != "" {
+			url := strings.TrimSpace(proxyURL)
+			return &url
+		}
+	}
+
+	return nil
+}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -10,21 +10,21 @@ func TestParseProxyForServer_Creds(t *testing.T) {
 	testURL := "http://BOB.BUILDER:ACOMPLICATEDPASSWORD@company.com:8080"
 	expected := "company.com"
 
-	assert.Equal(t, expected, parseProxyForServer(testURL))
+	assert.Equal(t, expected, parseProxyURLForDomain(testURL))
 }
 
 func TestParseProxyForServer_NoCreds(t *testing.T) {
 	testURL := "http://company.com:8080"
 	expected := "company.com"
 
-	assert.Equal(t, expected, parseProxyForServer(testURL))
+	assert.Equal(t, expected, parseProxyURLForDomain(testURL))
 }
 
 func TestParseProxyForServer_NoCredsHTTPS(t *testing.T) {
 	testURL := "https://company.com:8080"
 	expected := "company.com"
 
-	assert.Equal(t, expected, parseProxyForServer(testURL))
+	assert.Equal(t, expected, parseProxyURLForDomain(testURL))
 }
 
 func TestGetNoProxyDomains_NoneSet(t *testing.T) {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,0 +1,95 @@
+package simpleresty
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestParseProxyForServer_Creds(t *testing.T) {
+	testURL := "http://BOB.BUILDER:ACOMPLICATEDPASSWORD@company.com:8080"
+	expected := "company.com"
+
+	assert.Equal(t, expected, parseProxyForServer(testURL))
+}
+
+func TestParseProxyForServer_NoCreds(t *testing.T) {
+	testURL := "http://company.com:8080"
+	expected := "company.com"
+
+	assert.Equal(t, expected, parseProxyForServer(testURL))
+}
+
+func TestParseProxyForServer_NoCredsHTTPS(t *testing.T) {
+	testURL := "https://company.com:8080"
+	expected := "company.com"
+
+	assert.Equal(t, expected, parseProxyForServer(testURL))
+}
+
+func TestGetNoProxyDomains_NoneSet(t *testing.T) {
+	domains, isPresent := getNoProxyDomains()
+
+	assert.Equal(t, 0, len(domains))
+	assert.Equal(t, false, isPresent)
+}
+
+func TestGetNoProxyDomains_SingleSet_NO_PROXY(t *testing.T) {
+	_ = os.Setenv("NO_PROXY", "somedomain.com")
+	defer os.Unsetenv("NO_PROXY")
+
+	domains, isPresent := getNoProxyDomains()
+
+	assert.Equal(t, []string{"somedomain.com"}, domains)
+	assert.Equal(t, true, isPresent)
+}
+
+func TestGetNoProxyDomains_SingleSet_no_proxy(t *testing.T) {
+	_ = os.Setenv("no_proxy", "somedomain.com")
+	defer os.Unsetenv("no_proxy")
+
+	domains, isPresent := getNoProxyDomains()
+
+	assert.Equal(t, []string{"somedomain.com"}, domains)
+	assert.Equal(t, true, isPresent)
+}
+
+func TestGetNoProxyDomains_MultipleSet(t *testing.T) {
+	_ = os.Setenv("NO_PROXY", "somedomain.com, somedomain2.com")
+	defer os.Unsetenv("NO_PROXY")
+
+	domains, isPresent := getNoProxyDomains()
+
+	assert.Equal(t, []string{"somedomain.com", "somedomain2.com"}, domains)
+	assert.Equal(t, true, isPresent)
+}
+
+func TestGetNoProxyDomains_WildcardMultipleSet(t *testing.T) {
+	_ = os.Setenv("NO_PROXY", "*.somedomain.com, somedomain2.com")
+	defer os.Unsetenv("NO_PROXY")
+
+	domains, isPresent := getNoProxyDomains()
+
+	assert.Equal(t, []string{"somedomain.com", "somedomain2.com"}, domains)
+	assert.Equal(t, true, isPresent)
+}
+
+func TestGetNoProxyDomains_WildcardMultipleSet2(t *testing.T) {
+	_ = os.Setenv("NO_PROXY", "*.somedomain.*, somedomain2.com")
+	defer os.Unsetenv("NO_PROXY")
+
+	domains, isPresent := getNoProxyDomains()
+
+	assert.Equal(t, []string{"somedomain2.com"}, domains)
+	assert.Equal(t, true, isPresent)
+}
+
+func TestGetNoProxyDomains_MultipleSetWithOneInvalid(t *testing.T) {
+	_ = os.Setenv("NO_PROXY", "somedomain, test.somedomain2.com")
+	defer os.Unsetenv("NO_PROXY")
+
+	domains, isPresent := getNoProxyDomains()
+
+	assert.Equal(t, []string{"test.somedomain2.com"}, domains)
+	assert.Equal(t, true, isPresent)
+}

--- a/response.go
+++ b/response.go
@@ -34,6 +34,7 @@ type Response struct {
 	Body string
 }
 
+// checkResponse parses the HTTP response and returns the response and an error if applicable.
 func checkResponse(resp *resty.Response) (*Response, error) {
 	path, _ := url.QueryUnescape(resp.Request.URL)
 	r := &Response{Status: resp.Status(), StatusCode: resp.StatusCode(),

--- a/simpleresty.go
+++ b/simpleresty.go
@@ -2,30 +2,24 @@ package simpleresty
 
 import (
 	"github.com/go-resty/resty/v2"
-	"os"
 )
 
-var (
-	proxyVars = []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"}
-)
-
-// New function creates a new SimpleResty client.
+// New function creates a new simpleresty client with base url set to empty string.
 func New() *Client {
-	c := &Client{Client: resty.New()}
+	c := &Client{Client: resty.New(), baseURL: ""}
 
-	determineSetProxy(c)
+	// Set proxy if applicable
+	c.determineSetProxy()
 
 	return c
 }
 
-// determineSetProxy checks if any proxy variables are defined in the environment.
-// If so, set the first occurrence and exit the loop.
-func determineSetProxy(c *Client) {
-	for _, v := range proxyVars {
-		proxyUrl := os.Getenv(v)
-		if proxyUrl != "" {
-			c.SetProxy(proxyUrl)
-			break
-		}
-	}
+// NewWithBaseURL creates a new simpleresty client with base url set.
+func NewWithBaseURL(url string) *Client {
+	c := &Client{Client: resty.New(), baseURL: url}
+
+	// Set proxy if applicable
+	c.determineSetProxy()
+
+	return c
 }

--- a/simpleresty.go
+++ b/simpleresty.go
@@ -5,21 +5,22 @@ import (
 )
 
 // New function creates a new simpleresty client with base url set to empty string.
+//
+// Users can set the base string later in their code.
 func New() *Client {
-	c := &Client{Client: resty.New(), baseURL: ""}
-
-	// Set proxy if applicable
-	c.determineSetProxy()
-
+	c := NewWithBaseURL("")
 	return c
 }
 
 // NewWithBaseURL creates a new simpleresty client with base url set.
 func NewWithBaseURL(url string) *Client {
-	c := &Client{Client: resty.New(), baseURL: url}
+	c := &Client{Client: resty.New(), baseURL: url, proxyURL: nil, shouldSetProxy: false}
 
-	// Set proxy if applicable
-	c.determineSetProxy()
+	// Set no proxy domains if any
+	c.noProxyDomains, _ = getNoProxyDomains()
+
+	// Set proxy URL if any
+	c.proxyURL = getProxyURL()
 
 	return c
 }

--- a/simpleresty_test.go
+++ b/simpleresty_test.go
@@ -13,11 +13,30 @@ func TestDetermineSetProxy_HttpsBasic(t *testing.T) {
 	setErr := os.Setenv("https_proxy", "some.url:8080")
 	assert.Nil(t, setErr)
 
-	determineSetProxy(c)
+	c.determineSetProxy()
 
 	assert.Equal(t, true, c.IsProxySet())
 
 	_ = os.Setenv("https_proxy", "")
+}
+
+func TestDetermineSetProxy_HttpsBasicWithNoProxy(t *testing.T) {
+	c := &Client{Client: resty.New()}
+
+	c.SetBaseURL("somedirecturl.com")
+
+	setErr := os.Setenv("https_proxy", "some.url:8080")
+	setErr = os.Setenv("no_proxy", "somedirecturl.com")
+
+	assert.Nil(t, setErr)
+
+	c.determineSetProxy()
+
+	assert.Equal(t, true, c.IsProxySet())
+
+	_ = os.Unsetenv("https_proxy")
+	_ = os.Unsetenv("no_proxy")
+
 }
 
 func TestDetermineSetProxy_HttpBasic(t *testing.T) {
@@ -26,7 +45,7 @@ func TestDetermineSetProxy_HttpBasic(t *testing.T) {
 	setErr := os.Setenv("http_proxy", "some.url:8080")
 	assert.Nil(t, setErr)
 
-	determineSetProxy(c)
+	c.determineSetProxy()
 
 	assert.Equal(t, true, c.IsProxySet())
 
@@ -39,7 +58,7 @@ func TestDetermineSetProxy_NoneSet(t *testing.T) {
 	setErr := os.Setenv("https_proxy123", "some.url:8080")
 	assert.Nil(t, setErr)
 
-	determineSetProxy(c)
+	c.determineSetProxy()
 
 	assert.Equal(t, false, c.IsProxySet())
 

--- a/simpleresty_test.go
+++ b/simpleresty_test.go
@@ -1,66 +1,17 @@
 package simpleresty
 
 import (
-	"github.com/go-resty/resty/v2"
 	"github.com/stretchr/testify/assert"
-	"os"
 	"testing"
 )
 
-func TestDetermineSetProxy_HttpsBasic(t *testing.T) {
-	c := &Client{Client: resty.New()}
-
-	setErr := os.Setenv("https_proxy", "some.url:8080")
-	assert.Nil(t, setErr)
-
-	c.determineSetProxy()
-
-	assert.Equal(t, true, c.IsProxySet())
-
-	_ = os.Setenv("https_proxy", "")
+func TestNew(t *testing.T) {
+	assert.NotNil(t, New())
 }
 
-func TestDetermineSetProxy_HttpsBasicWithNoProxy(t *testing.T) {
-	c := &Client{Client: resty.New()}
+func TestNewWithBaseURL(t *testing.T) {
+	c := NewWithBaseURL("https://base.url/api/v3")
 
-	c.SetBaseURL("somedirecturl.com")
-
-	setErr := os.Setenv("https_proxy", "some.url:8080")
-	setErr = os.Setenv("no_proxy", "somedirecturl.com")
-
-	assert.Nil(t, setErr)
-
-	c.determineSetProxy()
-
-	assert.Equal(t, true, c.IsProxySet())
-
-	_ = os.Unsetenv("https_proxy")
-	_ = os.Unsetenv("no_proxy")
-
-}
-
-func TestDetermineSetProxy_HttpBasic(t *testing.T) {
-	c := &Client{Client: resty.New()}
-
-	setErr := os.Setenv("http_proxy", "some.url:8080")
-	assert.Nil(t, setErr)
-
-	c.determineSetProxy()
-
-	assert.Equal(t, true, c.IsProxySet())
-
-	_ = os.Setenv("http_proxy", "")
-}
-
-func TestDetermineSetProxy_NoneSet(t *testing.T) {
-	c := &Client{Client: resty.New()}
-
-	setErr := os.Setenv("https_proxy123", "some.url:8080")
-	assert.Nil(t, setErr)
-
-	c.determineSetProxy()
-
-	assert.Equal(t, false, c.IsProxySet())
-
-	_ = os.Setenv("https_proxy123", "")
+	assert.NotNil(t, c)
+	assert.Equal(t, "https://base.url/api/v3", c.baseURL)
 }


### PR DESCRIPTION
Reference:
- https://docs.chef.io/proxies/#no-proxy
- https://superuser.com/questions/944958/are-http-proxy-https-proxy-and-no-proxy-environment-variables-standard
- https://docs.openshift.com/container-platform/3.9/install_config/http_proxies.html#configuring-no-proxy
- https://www.golinuxcloud.com/set-up-proxy-http-proxy-environment-variable/

For now, support a comma separated string of domain names sans wildcard entries.

```shell
# export http_proxy=http://SERVER:PORT/
# export http_proxy=http://USERNAME:PASSWORD@SERVER:PORT/
# export http_proxy=http://DOMAIN\\USERNAME:PASSWORD@SERVER:PORT/
```